### PR TITLE
Comply with Go' module naming convention

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module terraform-provider-meraki
+module github.com/cisco-open/terraform-provider-meraki
 
 go 1.21.5
 

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"reflect"
-	tfsdkr "terraform-provider-meraki/internal/provider/reflects"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -17,6 +16,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+
+	tfsdkr "github.com/cisco-open/terraform-provider-meraki/internal/provider/reflects"
 )
 
 var simpleTypes = []string{

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ import (
 	"flag"
 	"log"
 
-	"terraform-provider-meraki/internal/provider"
+	"github.com/cisco-open/terraform-provider-meraki/internal/provider"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 )


### PR DESCRIPTION
## Description

[Go's module documentation](https://go.dev/doc/modules/layout) suggests that module [paths](https://go.dev/ref/mod#module-path) should be of the form

```
github.com/cisco-open/terraform-provider-meraki
^          ^          ^
VCS URL    ORG        REPO
```

This PR moves this repo to comply with Go's convention.

Motivation:

I work at [Pulumi](https://www.pulumi.com) and maintain [pulumi-meraki](https://github.com/pulumi/pulumi-meraki) (which is based off of [terraform-provider-meraki](https://github.com/cisco-open/terraform-provider-meraki)) for a shared customer. We have tooling to automatically detect provider upgrades that expects the module name to be standard.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [X] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
